### PR TITLE
fix(Part B, Ch. 4.2) - Change the code in Adapter-Example

### DIFF
--- a/Part B - Advanced/04_patterns/examples/adapter_with_composition.py
+++ b/Part B - Advanced/04_patterns/examples/adapter_with_composition.py
@@ -1,36 +1,36 @@
 # Example: Adapter Pattern (Object Adapter)
 
-class Channel_V1(object):
+class ChannelV1(object):
 
     @staticmethod
-    def applyConfig():
+    def apply_config():
         print('Configuration method of the old device class!')
 
 
-class Channel_V2(object):
+class ChannelV2(object):
 
     @staticmethod
     def configure():
         print('Configuration method of the new device class!')
 
 
-class ChannelAdapter(Channel_V1):
+class ChannelAdapter(ChannelV1):
     # Class adapter (with composition)
 
     def __init__(self, adaptee):
         self.adaptee = adaptee
 
-    def applyConfig(self):
+    def apply_config(self):
         self.adaptee.configure()
 
 
 def host_app(channel):
-    channel.applyConfig()
+    channel.apply_config()
 
 
 if __name__ == "__main__":
     # Original code using the old service
-    host_app(channel=Channel_V1())
+    host_app(channel=ChannelV1())
 
     # Use adapter for the new service adapted to the old interface
-    host_app(channel=ChannelAdapter(adaptee=Channel_V2()))
+    host_app(channel=ChannelAdapter(adaptee=ChannelV2()))

--- a/Part B - Advanced/04_patterns/examples/adapter_with_inheritance.py
+++ b/Part B - Advanced/04_patterns/examples/adapter_with_inheritance.py
@@ -1,36 +1,33 @@
 # Example: Adapter Pattern (Class Adapter)
 
-class Channel_V1(object):
+class ChannelV1(object):
 
     @staticmethod
-    def applyConfig():
+    def apply_config():
         print('Configuration method of the old device class!')
 
 
-class Channel_V2(object):
+class ChannelV2(object):
 
     @staticmethod
     def configure():
         print('Configuration method of the new device class!')
 
 
-class ChannelAdapter(Channel_V1, Channel_V2):
+class ChannelAdapter(ChannelV1, ChannelV2):
     # Class adapter (with inheritance)
 
-    def __init__(self, adaptee):
-        self.adaptee = adaptee
-
-    def applyConfig(self):
+    def apply_config(self):
         self.configure()
 
 
 def host_app(channel):
-    channel.applyConfig()
+    channel.apply_config()
 
 
 if __name__ == "__main__":
     # Original code using the old service
-    host_app(channel=Channel_V1())
+    host_app(channel=ChannelV1())
 
     # Use adapter for the new service adapted to the old interface
-    host_app(channel=ChannelAdapter(adaptee=Channel_V2()))
+    host_app(channel=ChannelAdapter())

--- a/Part B - Advanced/PYTHON_B.adoc
+++ b/Part B - Advanced/PYTHON_B.adoc
@@ -535,6 +535,13 @@ The object adapter uses composition to adapt one interface to another. It is imp
 creating a class that contains an instance of the adaptee class. It provides a way to adapt the
 interface of the adaptee class to the interface of the target class.
 
+
+[source,python]
+----
+include::04_patterns/examples/adapter_with_inheritance.py[]
+----
+
+
 [source,python]
 ----
 include::04_patterns/examples/adapter_with_composition.py[]


### PR DESCRIPTION
In addition to the changes I have made:

- As far as I understand the Adapter is for making old legacy code work with new code. In the examples the new code is adapted to the old. Perhaps a comment line over the classes with "Adaptee" and "Target" will help.

I found the two examples from the following link helpful:
https://refactoring.guru/design-patterns/adapter/python/example#example-0
