### PR TITLE
Add example header for argument unpacking

### DIFF
--- a/examples/07_functions/func_unpacking_arguments.py
+++ b/examples/07_functions/func_unpacking_arguments.py
@@ -1,3 +1,9 @@
+# Argument unpacking with `*args`
+# -----------------------------------------------------------------------------
+# When calling a function, the star operator can expand an iterable into
+# positional arguments. This allows you to store the arguments in a list or
+# other iterable and pass them all at once.
+
 def my_function(a, b, c):
     print(a, b, c)
 


### PR DESCRIPTION
## Summary
- explain argument unpacking with `*args` in the function example

## Testing
- `python examples/07_functions/func_unpacking_arguments.py`


------
https://chatgpt.com/codex/tasks/task_e_684910eb03b8832484534c2a643d02dc