### PR TITLE
Add Python2 and Python3 variable argument comparison

### DIFF
--- a/examples/07_functions/func_variable_arguments_python2.py
+++ b/examples/07_functions/func_variable_arguments_python2.py
@@ -1,3 +1,11 @@
+# Handling a variable number of arguments in Python 2
+# -----------------------------------------------------------------------------
+# Demonstrates capturing extra positional arguments with `*args` and
+# extra keyword arguments with `**kwargs` when keyword-only parameters are
+# unavailable.  In Python 3 you can declare keyword-only parameters using
+# the `*` separator instead of relying on `**kwargs`.  See
+# `func_variable_arguments_python3.py` for comparison.
+
 def variable_number_of_arguments(a, b, *args, **kwargs):
     print("a: {a}".format(a=a))
     print("b: {b}".format(b=b))

--- a/examples/07_functions/func_variable_arguments_python3.py
+++ b/examples/07_functions/func_variable_arguments_python3.py
@@ -1,3 +1,9 @@
+# Handling a variable number of arguments in Python 3
+# -----------------------------------------------------------------------------
+# Keyword-only arguments come after `*` so there is less need to use
+# `**kwargs` for optional named parameters.  Compare with the Python 2 version
+# in `func_variable_arguments_python2.py`.
+
 def variable_number_of_arguments(a, *args, b=1, **kwargs):
     print(f"a: {a}")
     print(f"b: {b}")


### PR DESCRIPTION
## Summary
- explain Python 2 `*args` / `**kwargs` use and reference Python 3 style
- document Python 3 keyword-only argument style

## Testing
- `python -m py_compile examples/07_functions/func_variable_arguments_python2.py`
- `python -m py_compile examples/07_functions/func_variable_arguments_python3.py`


------
https://chatgpt.com/codex/tasks/task_e_684910ec56e88324ad9ce14c9876af21