### PR TITLE
Add header for lambda assignment example

### DIFF
--- a/examples/07_functions/func_lambda_assignment.py
+++ b/examples/07_functions/func_lambda_assignment.py
@@ -1,2 +1,6 @@
+# Assigning a lambda expression to a variable
+# --------------------------------------------------------------------------------
+# Lambda expressions can be assigned to variables to create small, unnamed functions on the fly.
+
 nop = lambda: None
 print(nop())


### PR DESCRIPTION
## Summary
- refine lambda example header and add 80-character separator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684910e6489c83248ffd6c08b7d677ff