### PR TITLE
Add spacing after positional args comments

### DIFF
--- a/examples/07_functions/func_positional_arguments.py
+++ b/examples/07_functions/func_positional_arguments.py
@@ -1,3 +1,8 @@
+# Demonstrates how functions receive arguments by their position
+# -----------------------------------------------------------------------------
+# Each value is matched to a parameter based on where it appears,
+# so the order of the provided arguments matters.
+
 def greet(name, age):
     print("Hello, {0}! You are {1} years old.".format(name, age))
 


### PR DESCRIPTION
## Summary
- add a blank line after the header comments in `func_positional_arguments.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684910eb054c83249cec167f42f4bc3b