### PR TITLE
Add headers to import system examples

### DIFF
--- a/examples/17_import_system/__init__.py
+++ b/examples/17_import_system/__init__.py
@@ -1,0 +1,1 @@
+"""Examples showing different aspects of Python's import system."""

--- a/examples/17_import_system/circular/__init__.py
+++ b/examples/17_import_system/circular/__init__.py
@@ -1,0 +1,1 @@
+"""Package demonstrating circular imports."""

--- a/examples/17_import_system/circular/submodule1.py
+++ b/examples/17_import_system/circular/submodule1.py
@@ -1,3 +1,4 @@
+"""First module in a circular import chain."""
 from . import submodule2
 
 

--- a/examples/17_import_system/circular/submodule2.py
+++ b/examples/17_import_system/circular/submodule2.py
@@ -1,3 +1,4 @@
+"""Second module that completes the circular import chain."""
 from . import submodule1
 
 def func2():

--- a/examples/17_import_system/export_decorator.py
+++ b/examples/17_import_system/export_decorator.py
@@ -1,3 +1,4 @@
+"""Defines an export decorator for populating a package's __all__."""
 # Example of the export decorator that shall be placed in the __init__.py file of the package
 
 # Export decorator

--- a/examples/17_import_system/foo/__init__.py
+++ b/examples/17_import_system/foo/__init__.py
@@ -1,3 +1,4 @@
+"""Demo package with relative imports and an export decorator."""
 # Define the packet API
 __version__ = '1.0.0'
 

--- a/examples/17_import_system/foo/__main__.py
+++ b/examples/17_import_system/foo/__main__.py
@@ -1,3 +1,4 @@
+"""Entry point executed when running the package with -m."""
 import sys
 import os.path
 

--- a/examples/17_import_system/foo/api/__init__.py
+++ b/examples/17_import_system/foo/api/__init__.py
@@ -1,1 +1,2 @@
+"""API subpackage exposing a version constant."""
 __version__ = '0.1.0'

--- a/examples/17_import_system/foo/api/submodule1.py
+++ b/examples/17_import_system/foo/api/submodule1.py
@@ -1,3 +1,4 @@
+"""Submodule used to demonstrate absolute and relative imports."""
 # Define a constant
 my_id = 1
 

--- a/examples/17_import_system/foo/core/__init__.py
+++ b/examples/17_import_system/foo/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core subpackage used in import examples."""

--- a/examples/17_import_system/foo/core/submodule2.py
+++ b/examples/17_import_system/foo/core/submodule2.py
@@ -1,3 +1,4 @@
+"""Submodule used in absolute import demonstrations."""
 # Define a constant
 my_id = 2
 

--- a/examples/17_import_system/foo/gui/__init__.py
+++ b/examples/17_import_system/foo/gui/__init__.py
@@ -1,0 +1,1 @@
+"""GUI subpackage used in import examples."""

--- a/examples/17_import_system/foo/gui/submodule3.py
+++ b/examples/17_import_system/foo/gui/submodule3.py
@@ -1,3 +1,4 @@
+"""Submodule used by GUI package import examples."""
 # Define a constant
 my_id = 3
 

--- a/examples/17_import_system/import_absolute.py
+++ b/examples/17_import_system/import_absolute.py
@@ -1,3 +1,4 @@
+"""Shows how to enforce and use absolute imports."""
 # Example: Absolute imports
 import asyncio
 

--- a/examples/17_import_system/import_circular.py
+++ b/examples/17_import_system/import_circular.py
@@ -1,3 +1,4 @@
+"""Triggers a circular import between two submodules."""
 import circular.submodule1 as submodule1
 
 submodule1.func1()

--- a/examples/17_import_system/import_conditional.py
+++ b/examples/17_import_system/import_conditional.py
@@ -1,3 +1,4 @@
+"""Shows conditional imports based on Python version."""
 import sys
 
 # Option 1

--- a/examples/17_import_system/import_main_module.py
+++ b/examples/17_import_system/import_main_module.py
@@ -1,3 +1,4 @@
+"""Demonstrates __main__ name when executing a module as a script."""
 # Example: Main program
 
 import pprint

--- a/examples/17_import_system/import_module_objects.py
+++ b/examples/17_import_system/import_module_objects.py
@@ -1,3 +1,4 @@
+"""Shows manual creation of ModuleType objects to demonstrate import internals."""
 from types import ModuleType
 
 # Create a new module object

--- a/examples/17_import_system/import_namespaces.py
+++ b/examples/17_import_system/import_namespaces.py
@@ -1,3 +1,4 @@
+"""Explores namespaces at different scopes using builtins and custom classes."""
 # Example: Namespace of the builtins module
 
 import pprint

--- a/examples/17_import_system/import_packages.py
+++ b/examples/17_import_system/import_packages.py
@@ -1,3 +1,4 @@
+"""Demonstrates importing a package and using its public API."""
 import product
 
 # Use the public API defined in __init__.py

--- a/examples/17_import_system/import_process.py
+++ b/examples/17_import_system/import_process.py
@@ -1,3 +1,4 @@
+"""Implements a minimal importer to show how Python loads modules."""
 # Example: Very naive implementation of the import statement
 
 import marshal

--- a/examples/17_import_system/import_search_path.py
+++ b/examples/17_import_system/import_search_path.py
@@ -1,3 +1,4 @@
+"""Displays and modifies sys.path to demonstrate search paths."""
 # Example: Import Search Path
 
 import sys

--- a/examples/17_import_system/import_skip_execution.py
+++ b/examples/17_import_system/import_skip_execution.py
@@ -1,3 +1,4 @@
+"""Demonstrates guarding code with __name__ to skip execution on import."""
 # Example: Main program
 
 

--- a/examples/17_import_system/import_statements.py
+++ b/examples/17_import_system/import_statements.py
@@ -1,3 +1,4 @@
+"""Illustrates various forms of the import statement."""
 # Example: Import Statements
 
 # Importing the package

--- a/examples/17_import_system/import_sys_path.py
+++ b/examples/17_import_system/import_sys_path.py
@@ -1,3 +1,4 @@
+"""Shows sys.path details via prefix values."""
 import sys
 print(sys.prefix)
 print(sys.exec_prefix)

--- a/examples/17_import_system/import_tracking.py
+++ b/examples/17_import_system/import_tracking.py
@@ -1,3 +1,4 @@
+"""Replaces builtins.__import__ to trace loaded modules."""
 def my_import(modname, *args, imp=__import__):
     print('importing', modname)
     return imp(modname, *args)

--- a/examples/17_import_system/rootdir.py
+++ b/examples/17_import_system/rootdir.py
@@ -1,3 +1,4 @@
+"""Holds the absolute path to this directory for search path examples."""
 import os
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- document how each module in the import system examples works
- cover packages `foo` and `circular`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684922bde11c8324895382ed9d0c3d98