### PR TITLE
Add explanatory headers to dunder examples

### DIFF
--- a/examples/15_dunder_methods/__init__.py
+++ b/examples/15_dunder_methods/__init__.py
@@ -1,0 +1,3 @@
+# Dunder method examples
+# ---------------------------------------------------------------------------
+# Examples demonstrating how special methods customize object behavior

--- a/examples/15_dunder_methods/demo_iterator.py
+++ b/examples/15_dunder_methods/demo_iterator.py
@@ -1,11 +1,10 @@
-"""
-* An iterable is an object that implements the __iter__ method which returns an iterator.
-* An iterator is an object that implements the __iter__ method which returns itself and the __next__ method which
-returns the next element.
-
-https://www.pythontutorial.net/advanced-python/python-iterator-vs-iterable/
-
-"""
+# Dunder methods and iteration
+# ---------------------------------------------------------------------------
+# Demonstrates how special methods customize iteration behavior.
+# * An iterable implements __iter__ returning an iterator.
+# * An iterator implements __iter__ returning itself and __next__ returning
+#   the next element.
+# https://www.pythontutorial.net/advanced-python/python-iterator-vs-iterable/
 
 
 ##################################################################################################

--- a/examples/15_dunder_methods/dunder_arithmetic_operators.py
+++ b/examples/15_dunder_methods/dunder_arithmetic_operators.py
@@ -1,4 +1,8 @@
-# Example: Dunder methods for arithmetic operators
+# Dunder methods for arithmetic operators
+# ---------------------------------------------------------------------------
+# By defining special arithmetic methods, objects can participate in Python's
+# numeric operations. These dunder hooks let a class customize how instances
+# respond to +, -, *, and other operators.
 
 class Complex(object):
 

--- a/examples/15_dunder_methods/dunder_attributes.py
+++ b/examples/15_dunder_methods/dunder_attributes.py
@@ -1,4 +1,8 @@
-# Example: Dunder methods for context manager
+# Dunder methods for attribute access
+# ---------------------------------------------------------------------------
+# Attribute related dunder methods such as __getattr__, __setattr__ and
+# __delattr__ give objects dynamic control over attribute access. They enable
+# customized lookup, assignment and deletion behavior.
 
 class Complex(object):
 

--- a/examples/15_dunder_methods/dunder_builtin_types.py
+++ b/examples/15_dunder_methods/dunder_builtin_types.py
@@ -1,4 +1,8 @@
-# Example: Dunder methods for object representation
+# Dunder methods for object representation
+# ---------------------------------------------------------------------------
+# Built-in type conversion functions like bool(), int() and bytes() call
+# corresponding dunder methods on objects. Implementing these hooks lets a
+# class define how it converts to fundamental Python types.
 
 import struct
 import math

--- a/examples/15_dunder_methods/dunder_context_manager.py
+++ b/examples/15_dunder_methods/dunder_context_manager.py
@@ -1,4 +1,8 @@
-# Example: Dunder methods for context manager
+# Dunder methods for context manager
+# ---------------------------------------------------------------------------
+# The __enter__ and __exit__ methods allow an object to define its own
+# setup and teardown logic when used in a with-statement. This example shows
+# how implementing these hooks customizes resource management behavior.
 
 class Complex(object):
 

--- a/examples/15_dunder_methods/dunder_customize_behavior.py
+++ b/examples/15_dunder_methods/dunder_customize_behavior.py
@@ -1,4 +1,8 @@
-# Example: Dunder methods for customizing object behavior
+# Dunder methods for customizing object behavior
+# ---------------------------------------------------------------------------
+# This script demonstrates several special methods that hook into object
+# creation, calling and destruction. Implementing these dunder methods lets a
+# class take control over how instances are created, invoked and cleaned up.
 
 class TestClass(object):
 

--- a/examples/15_dunder_methods/dunder_iterator_protocol.py
+++ b/examples/15_dunder_methods/dunder_iterator_protocol.py
@@ -1,4 +1,9 @@
-# Example: Dunder methods for the iterator protocol
+# Dunder methods for the iterator protocol
+# ---------------------------------------------------------------------------
+# Special (dunder) methods allow objects to integrate with Python features.
+# By implementing __iter__ and __next__, this class customizes iteration
+# behavior so that instances work seamlessly in for-loops and other iterable
+# contexts.
 
 class Stack(object):
 

--- a/examples/15_dunder_methods/dunder_object_representation.py
+++ b/examples/15_dunder_methods/dunder_object_representation.py
@@ -1,4 +1,8 @@
-# Example: Dunder methods for object representation
+# Dunder methods for object representation
+# ---------------------------------------------------------------------------
+# Special representation methods like __repr__ and __str__ let objects control
+# how they are displayed. This example highlights how these hooks customize the
+# string and byte output of a class.
 
 import struct
 

--- a/examples/15_dunder_methods/dunder_operator_overloading.py
+++ b/examples/15_dunder_methods/dunder_operator_overloading.py
@@ -1,4 +1,8 @@
-# Example: Dunder methods for operator overloading
+# Dunder methods for operator overloading
+# ---------------------------------------------------------------------------
+# Overloading arithmetic operators with dunder methods allows custom classes
+# to behave like built-in numeric types. The following Point class defines
+# how instances react to +, -, * and other operations.
 
 class Point(object):
 

--- a/examples/15_dunder_methods/snippets.py
+++ b/examples/15_dunder_methods/snippets.py
@@ -1,3 +1,7 @@
+# Demonstration of special methods
+# ---------------------------------------------------------------------------
+# Various dunder methods show how objects integrate with Python features
+
 class DunderClass(object):
 
     def __init__(self):


### PR DESCRIPTION
## Summary
- document dunder method features via comment headers
- replace demo_iterator module docstring with header
- remove `Example:` token from each module title

## Testing
- `python -m py_compile $(git ls-files 'examples/15_dunder_methods/*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684922b95f088324b4864789a9f9e40c