### PR TITLE
Add structured headers to exception examples

### DIFF
--- a/examples/14_exceptions/__init__.py
+++ b/examples/14_exceptions/__init__.py
@@ -1,0 +1,4 @@
+# Exception Example Package
+# --------------------------------------------------------------------------------
+# Contains modules demonstrating custom exception hierarchies and handling
+# patterns.

--- a/examples/14_exceptions/demo_generation.py
+++ b/examples/14_exceptions/demo_generation.py
@@ -1,3 +1,8 @@
+# Old-Style Exception Generation
+# --------------------------------------------------------------------------------
+# Shows what happens when raising an exception class that does not inherit from
+# BaseException.
+
 # class NewStyleException(Exception): pass
 #
 # try:

--- a/examples/14_exceptions/demo_handlers.py
+++ b/examples/14_exceptions/demo_handlers.py
@@ -1,3 +1,8 @@
+# Exception Handling Styles
+# --------------------------------------------------------------------------------
+# Compares using a single except clause against multiple specific handlers for
+# related errors.
+
 def raise_overflow_error():
     raise OverflowError
 

--- a/examples/14_exceptions/exception_catch_multiple.py
+++ b/examples/14_exceptions/exception_catch_multiple.py
@@ -1,4 +1,7 @@
-# Example: Catch Multiple Exceptions with junior Single Except Block
+# Grouped Exception Handling
+# --------------------------------------------------------------------------------
+# Illustrates catching different members of an exception hierarchy with one
+# except block.
 
 
 from exception_hierarchy import *

--- a/examples/14_exceptions/exception_chaining.py
+++ b/examples/14_exceptions/exception_chaining.py
@@ -1,4 +1,7 @@
-# Example: Exception Chaining
+# Exception Chaining
+# --------------------------------------------------------------------------------
+# Demonstrates explicit and implicit chaining of exceptions to preserve the
+# original error context.
 
 class MyException(Exception):
     pass

--- a/examples/14_exceptions/exception_files.txt
+++ b/examples/14_exceptions/exception_files.txt
@@ -1,3 +1,7 @@
+# Exception Files Layout
+# --------------------------------------------------------------------------------
+# Displays a sample directory tree for keeping custom error definitions organized.
+
 src/
  ├─ socket
  │  ├─ __init__.py

--- a/examples/14_exceptions/exception_flow_with_try_except.py
+++ b/examples/14_exceptions/exception_flow_with_try_except.py
@@ -1,4 +1,6 @@
-# Example: Exception Flow with try-except statements
+# Control Flow with try/except
+# --------------------------------------------------------------------------------
+# Shows normal execution resuming after errors are caught and handled.
 def func_a(x):
     # Function uses and returns only positive values
     if x < 0:

--- a/examples/14_exceptions/exception_flow_without_try_except.py
+++ b/examples/14_exceptions/exception_flow_without_try_except.py
@@ -1,4 +1,6 @@
-# Example of exception flow without try/except statements
+# Control Flow without try/except
+# --------------------------------------------------------------------------------
+# Illustrates manual error checking when no exception handlers are used.
 
 def func_a(x):
     # Function uses and returns only positive values

--- a/examples/14_exceptions/exception_handling.py
+++ b/examples/14_exceptions/exception_handling.py
@@ -1,4 +1,6 @@
-# Example: Exception Handling with try-except statements
+# Structured Exception Handling
+# --------------------------------------------------------------------------------
+# Uses try/except/else/finally blocks to handle expected and unexpected errors.
 
 import time
 

--- a/examples/14_exceptions/exception_hierarchy.py
+++ b/examples/14_exceptions/exception_hierarchy.py
@@ -1,4 +1,7 @@
-# Example: Exception Hierarchy in junior Package
+# Custom Exception Hierarchy
+# --------------------------------------------------------------------------------
+# Defines a family of related custom exceptions and demonstrates raising each
+# member of the hierarchy.
 
 class SocketError(Exception):
 


### PR DESCRIPTION
## Summary
- add descriptive headers to each example in `examples/14_exceptions`
- use 80 hyphen separators to highlight each heading

## Testing
- `pytest -q`
- `python -m py_compile examples/14_exceptions/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684922b6ef6c832499c4535bac0a0820