### PR TITLE
Add heading separators for logging examples

### DIFF
--- a/examples/13_logging/logging_advanced_config.py
+++ b/examples/13_logging/logging_advanced_config.py
@@ -1,4 +1,6 @@
-# Example: Basic and Advanced Logging Configuration
+# Advanced Logging Configuration
+# --------------------------------------------------------------------------------
+# Demonstrates custom handlers, a formatter, and propagation control.
 
 import logging
 

--- a/examples/13_logging/logging_basic_config.py
+++ b/examples/13_logging/logging_basic_config.py
@@ -1,4 +1,6 @@
-# Example: Basic and Advanced Logging Configuration
+# Basic Logging Configuration
+# --------------------------------------------------------------------------------
+# Uses basicConfig for the root logger and a named child logger.
 
 import logging
 

--- a/examples/13_logging/logging_config_dict.py
+++ b/examples/13_logging/logging_config_dict.py
@@ -1,4 +1,6 @@
-# Example: Logging Configuration with a Dictionary
+# Logging Configuration with a Dictionary
+# --------------------------------------------------------------------------------
+# Uses a dict to define formatters, handlers and loggers.
 
 import logging.config
 

--- a/examples/13_logging/logging_config_file.py
+++ b/examples/13_logging/logging_config_file.py
@@ -1,4 +1,6 @@
-# Example: Configure the logging module with a configuration file
+# Configuring Logging from a File
+# --------------------------------------------------------------------------------
+# Loads logger settings from an external configuration file.
 
 import logging.config
 

--- a/examples/13_logging/logging_exceptions.py
+++ b/examples/13_logging/logging_exceptions.py
@@ -1,3 +1,7 @@
+# Logging Exceptions
+# --------------------------------------------------------------------------------
+# Captures an exception and logs the full stack trace.
+
 import logging
 
 a = 5

--- a/examples/13_logging/logging_formatter.py
+++ b/examples/13_logging/logging_formatter.py
@@ -1,4 +1,6 @@
-# Example: Basic and Advanced Logging Configuration
+# Custom Logging Formatter
+# --------------------------------------------------------------------------------
+# Configures a formatter for a named logger.
 
 import logging
 

--- a/examples/13_logging/logging_handlers.py
+++ b/examples/13_logging/logging_handlers.py
@@ -1,3 +1,7 @@
+# Multiple Logging Handlers
+# --------------------------------------------------------------------------------
+# Sets up stream, file and timed rotating handlers.
+
 import logging.handlers
 import time
 

--- a/examples/13_logging/logging_hierarchy.py
+++ b/examples/13_logging/logging_hierarchy.py
@@ -1,4 +1,6 @@
-# Example: Logging Objects with hierarchy
+# Logger Hierarchy
+# --------------------------------------------------------------------------------
+# Shows parent, child and grandchild loggers working together.
 
 import logging
 

--- a/examples/13_logging/logging_levels.py
+++ b/examples/13_logging/logging_levels.py
@@ -1,4 +1,6 @@
-# Example: Logging Levels
+# Logging Levels
+# --------------------------------------------------------------------------------
+# Demonstrates how to emit messages for each severity level.
 
 import logging
 


### PR DESCRIPTION
## Summary
- revise logging example headers with 80 character separators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684922b69e0c8324b74e60405ba27a76