### PR TITLE
Add SOLID principle headers

### DIFF
--- a/examples/12_solid_principles/dependency_inversion_bad.py
+++ b/examples/12_solid_principles/dependency_inversion_bad.py
@@ -1,4 +1,8 @@
-# Example: A bad example that violates the Dependency Inversion Principle
+# Dependency Inversion Principle - Bad Example
+# -------------------------------------------------------------------------------
+# The Dependency Inversion Principle (DIP) dictates that high level
+# modules should not depend on low level ones directly. Calculator
+# instantiates Math itself and so is tightly coupled to it.
 
 
 class Math(object):

--- a/examples/12_solid_principles/dependency_inversion_good.py
+++ b/examples/12_solid_principles/dependency_inversion_good.py
@@ -1,4 +1,8 @@
-# Example : A good example that follows the Dependency Inversion Principle
+# Dependency Inversion Principle - Good Example
+# -------------------------------------------------------------------------------
+# The Dependency Inversion Principle (DIP) encourages depending on
+# abstractions rather than concrete classes. Calculator receives an
+# IMath implementation, decoupling it from a specific Math class.
 
 class IMath(object):
     """ Simplified interface for junior math class """

--- a/examples/12_solid_principles/interface_segregation_bad.py
+++ b/examples/12_solid_principles/interface_segregation_bad.py
@@ -1,4 +1,9 @@
-# Example: A bad example that violates the Interface Segregation Principle
+# Interface Segregation Principle - Bad Example
+# -------------------------------------------------------------------------------
+# The Interface Segregation Principle (ISP) advises that clients
+# should not be forced to depend on methods they do not use. The
+# Device class defines unrelated operations that specific devices
+# need to ignore.
 
 class Device(object):
 

--- a/examples/12_solid_principles/interface_segregation_good.py
+++ b/examples/12_solid_principles/interface_segregation_good.py
@@ -1,4 +1,8 @@
-# Example: A good example that follows the Interface Segregation Principle
+# Interface Segregation Principle - Good Example
+# -------------------------------------------------------------------------------
+# The Interface Segregation Principle (ISP) breaks large interfaces
+# into focused ones. Mixins here provide only the operations each
+# device actually needs.
 
 class Device(object):
     # Defines only the common methods for all devices

--- a/examples/12_solid_principles/liskov_substitution_bad.py
+++ b/examples/12_solid_principles/liskov_substitution_bad.py
@@ -1,4 +1,8 @@
-# Example:  A bad example that violates the Liskov Substitution Principle
+# Liskov Substitution Principle - Bad Example
+# -------------------------------------------------------------------------------
+# The Liskov Substitution Principle (LSP) requires that subclasses
+# can stand in for their base class. Here the work method checks
+# for `Baby` explicitly, so `Baby` cannot substitute `Human`.
 
 class Human(object):
 

--- a/examples/12_solid_principles/liskov_substitution_good.py
+++ b/examples/12_solid_principles/liskov_substitution_good.py
@@ -1,4 +1,9 @@
-# Example:  A good example that follows the Liskov Substitution Principle
+# Liskov Substitution Principle - Good Example
+# -------------------------------------------------------------------------------
+# The Liskov Substitution Principle (LSP) means that objects of a
+# superclass should be replaceable with objects of its subclasses
+# without breaking the program. Each subclass here simply extends
+# Human without special checks.
 
 class Human(object):
 

--- a/examples/12_solid_principles/open_closed_bad.py
+++ b/examples/12_solid_principles/open_closed_bad.py
@@ -1,4 +1,8 @@
-# Example : A bad example that violates the Open/Closed Principle
+# Open/Closed Principle - Bad Example
+# -------------------------------------------------------------------------------
+# The Open/Closed Principle (OCP) states that code should be open for
+# extension but closed for modification. Adding a new format here
+# requires changing the FileProcessor class, so OCP is violated.
 
 class FileProcessor(object):
 

--- a/examples/12_solid_principles/open_closed_good.py
+++ b/examples/12_solid_principles/open_closed_good.py
@@ -1,4 +1,8 @@
-# Example : A good example that follows the Open/Closed Principle
+# Open/Closed Principle - Good Example
+# -------------------------------------------------------------------------------
+# The Open/Closed Principle (OCP) says that classes should be
+# extendable without needing to modify their source. FileProcessor
+# composes formatter objects so new behaviour can be added safely.
 
 class LowercaseFormat(object):
 

--- a/examples/12_solid_principles/single_responsibility_bad.py
+++ b/examples/12_solid_principles/single_responsibility_bad.py
@@ -1,4 +1,8 @@
-# Example : An example that violates the Single Responsibility Principle
+# Single Responsibility Principle - Bad Example
+# -------------------------------------------------------------------------------
+# The Single Responsibility Principle (SRP) says that a class should
+# have only one reason to change. This example bundles reading,
+# writing and processing into one class, so it breaks SRP.
 
 class MyCustomFileFormat(object):
     """ This class violates the Single Responsibility Principle because:

--- a/examples/12_solid_principles/single_responsibility_good.py
+++ b/examples/12_solid_principles/single_responsibility_good.py
@@ -1,4 +1,8 @@
-# Example : An example that follows the Single Responsibility Principle
+# Single Responsibility Principle - Good Example
+# -------------------------------------------------------------------------------
+# The Single Responsibility Principle (SRP) states that a class should
+# do only one thing. Here the reading, writing and processing logic
+# are split into separate classes.
 
 # By splitting the class into three classes, we can now reuse the classes in
 # other parts of the program. A change in one class will not affect the other


### PR DESCRIPTION
## Summary
- reformat SOLID examples with 80-char separators and remove `Example:` token

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in examples/02_variables/var_immutable.py)*

------
https://chatgpt.com/codex/tasks/task_e_684922b5232c83248dc123618832be98