### PR TITLE
Update README with OS-specific installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,19 @@ Ensure that the following tools are installed before setting up the project:
 
 Create a virtual environment and install dependencies:
 
+### Linux/macOS
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Windows
+
+```cmd
+python -m venv .venv
+.\.venv\Scripts\activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
- expand installation section in README with instructions for Linux/macOS and Windows

## Testing
- `pytest examples/19_test_frameworks/tests/testing_pytest.py -q` *(fails: ImportError: attempted relative import beyond top-level package)*

------
https://chatgpt.com/codex/tasks/task_e_6849257276b08324a04ad8b6aabf0e03