### PR TITLE
Fix headings in 07_functions

### DIFF
--- a/examples/07_functions/func_callback.py
+++ b/examples/07_functions/func_callback.py
@@ -1,8 +1,9 @@
 # Using callback functions to handle events
 # --------------------------------------------------------------------------------
-# A callback function is a function that is passed as an argument to another
-# function and is executed at the appropriate time, often in response to an
-# event.
+# A callback function is passed as an argument to another function and executed
+# when a particular event occurs. This technique lets the caller customize
+# behavior without changing the callee. Callbacks are common in event-driven
+# architectures and asynchronous code.
 
 _listeners = {}
 

--- a/examples/07_functions/func_default_arguments.py
+++ b/examples/07_functions/func_default_arguments.py
@@ -1,7 +1,8 @@
 # Default arguments in functions
 # --------------------------------------------------------------------------------
-# Each function can have default arguments, which are used if the caller does
-# not provide a value for that argument.
+# Functions may define default values for parameters so callers can omit those
+# arguments. This simplifies the call site and allows optional behavior.
+# Remember that default expressions are evaluated when the function is defined.
 
 def greet(name='Nemo', age=42):
     print("Hello, {0}! You are {1} years old.".format(name, age))

--- a/examples/07_functions/func_factory.py
+++ b/examples/07_functions/func_factory.py
@@ -1,7 +1,8 @@
 # Function factories to create specialized functions
 # --------------------------------------------------------------------------------
-# This example uses higher-order functions to generate customized
-# functions.
+# A function factory returns a new function tailored to the argument it
+# receives. It enables creation of many small functions without repeating code.
+# Each generated function captures the parameters provided to the factory.
 
 def power_of(n):
     def power(x):

--- a/examples/07_functions/func_introspection.py
+++ b/examples/07_functions/func_introspection.py
@@ -1,7 +1,10 @@
 # Inspect function attributes
 # --------------------------------------------------------------------------------
-# Explore attributes such as __name__, __doc__, __code__, etc., to see
-# where Python stores metadata for functions.
+# Python stores a variety of metadata about functions on the function object
+# itself. Attributes such as ``__name__``, ``__doc__`` and ``__code__`` can be
+# inspected at runtime to learn more about a function's definition. This
+# introspection ability is useful for debugging and for frameworks that
+# manipulate functions.
 
 def foo(a, b=10, c=20, *args, **kwargs):
     """This is 'foo' function that does nothing."""

--- a/examples/07_functions/func_keyword_arguments.py
+++ b/examples/07_functions/func_keyword_arguments.py
@@ -1,7 +1,9 @@
 # Calling functions with keyword arguments
 # --------------------------------------------------------------------------------
-# Describe how naming parameters improves readability and allows optional
-# argument ordering.
+# When a function call includes parameter names, the order of those arguments no
+# longer matters. Keyword arguments make the call site clearer and allow some
+# parameters to be skipped if they have defaults. They also pair well with
+# functions that accept many optional settings.
 
 def greet(name, age):
     print("Hello, {0}! You are {1} years old.".format(name, age))

--- a/examples/07_functions/func_keyword_only_arguments.py
+++ b/examples/07_functions/func_keyword_only_arguments.py
@@ -1,6 +1,8 @@
 # Keyword-only arguments
 # --------------------------------------------------------------------------------
-# Demonstrates keyword-only arguments.
+# Keyword-only parameters must be specified by name in the call. This avoids
+# ambiguity and makes the purpose of each argument clear. It is particularly
+# helpful when a function accepts many optional parameters.
 
 # The arguments a and b are keyword-only
 def keyword_only_arguments(*, a, b):

--- a/examples/07_functions/func_lambda_arguments.py
+++ b/examples/07_functions/func_lambda_arguments.py
@@ -1,6 +1,9 @@
 # Lambda functions with multiple arguments
 # --------------------------------------------------------------------------------
-# Demonstrates lambda functions with multiple arguments.
+# A lambda expression can accept several parameters just like a regular
+# function. It is useful for short, inline operations where defining a full
+# function would be excessive. Here we compute a simple expression using five
+# arguments.
 
 # Multi-parameter lambda
 x = lambda a, b, c, d, e: (a + b) * (c + d) / e

--- a/examples/07_functions/func_lambda_assignment.py
+++ b/examples/07_functions/func_lambda_assignment.py
@@ -1,6 +1,8 @@
 # Assigning a lambda expression to a variable
 # --------------------------------------------------------------------------------
-# Lambda expressions can be assigned to variables to create small, unnamed functions on the fly.
+# Lambda expressions can be assigned to variables to create small, unnamed
+# functions on the fly. Doing so lets you reuse the lambda just like a regular
+# function object. This pattern is handy for callbacks or short computations.
 
 nop = lambda: None
 print(nop())

--- a/examples/07_functions/func_lambda_bytecodes.py
+++ b/examples/07_functions/func_lambda_bytecodes.py
@@ -1,7 +1,8 @@
 # Lambda and def produce the same bytecode
 # --------------------------------------------------------------------------------
 # This script compiles a lambda expression and a regular function to compare
-# their bytecode output.
+# their bytecode output. Both forms compile into nearly identical instructions.
+# Using ``lambda`` therefore carries no extra runtime cost compared to ``def``.
 
 import dis
 

--- a/examples/07_functions/func_lambda_conditional.py
+++ b/examples/07_functions/func_lambda_conditional.py
@@ -1,5 +1,8 @@
 # Conditional lambda
 # --------------------------------------------------------------------------------
-# Demonstrates conditional lambda.
+# A lambda can contain a conditional expression to produce different values
+# based on its input. This one returns ``1`` when the argument is positive and
+# ``0`` otherwise. Such compact expressions are useful for simple
+# transformations.
 y = lambda b: 1 if b > 0 else 0
 print(y(-1), y(0), y(1))

--- a/examples/07_functions/func_lambda_nested_conditions.py
+++ b/examples/07_functions/func_lambda_nested_conditions.py
@@ -1,7 +1,8 @@
 # Lambda function with nested conditionals
 # --------------------------------------------------------------------------------
-# This example defines a lambda expression that returns `1` when the input
-# is greater than 10 or less than -10 and `0` otherwise.
+# This lambda expression checks two ranges using nested conditional operators.
+# It returns ``1`` when the argument exceeds 10 or falls below -10 and ``0`` in
+# all other cases. The expression remains concise despite the multiple branches.
 z = lambda c: 1 if c > 10 else (1 if c < -10 else 0)
 print(-11, -10, -1, 0, 1, 10, 11, sep='\t')
 print(z(-11), z(-10), z(-1), z(0), z(1), z(10), z(11), sep='\t')

--- a/examples/07_functions/func_lambda_recursive.py
+++ b/examples/07_functions/func_lambda_recursive.py
@@ -1,6 +1,9 @@
 # Lambda function with recursion
 # --------------------------------------------------------------------------------
-# Demonstrates lambda function with recursion.
+# Although lambdas are typically simple, they can also be used recursively.
+# The expression here computes factorial by calling itself for successive
+# decrements. Assigning the lambda to a variable is required so it can
+# reference itself.
 
 x = lambda a: a * x(a - 1) if a > 1 else 1
 print(x(5))

--- a/examples/07_functions/func_lambda_syntax.py
+++ b/examples/07_functions/func_lambda_syntax.py
@@ -1,6 +1,9 @@
 # Lambda functions
 # --------------------------------------------------------------------------------
-# Demonstrates lambda functions.
+# Lambda expressions provide a compact way to create anonymous functions.
+# They consist of a parameter list, a colon and a single expression that becomes
+# the return value. Because they are limited to one expression, lambdas are best
+# suited for small operations.
 
 """
 lambda [param1, param2, ..]: expression

--- a/examples/07_functions/func_memoization.py
+++ b/examples/07_functions/func_memoization.py
@@ -1,4 +1,4 @@
-# Demonstrates memoization with an inner function that caches results.
+# Memoization with an inner function that caches results
 # --------------------------------------------------------------------------------
 # The inner ``memoized_fibonacci`` function stores each computed Fibonacci
 # number in the ``cache`` dictionary. On subsequent calls with the same

--- a/examples/07_functions/func_nested.py
+++ b/examples/07_functions/func_nested.py
@@ -1,6 +1,9 @@
 # Nested functions and their access to enclosing variables
 # --------------------------------------------------------------------------------
-# Explains how inner functions can access variables from their enclosing functions.
+# Inner functions can access variables from the outer function that defines
+# them. This ability creates a closure which preserves the environment even
+# after the outer function has finished executing. It allows the inner function
+# to operate using data that would otherwise be out of scope.
 
 def absolute_value(x):
     # Emulate the built-in abs() function, e.g. abs(-1) == 1 and abs(1) == 1

--- a/examples/07_functions/func_positional_arguments.py
+++ b/examples/07_functions/func_positional_arguments.py
@@ -1,7 +1,9 @@
-# Demonstrates how functions receive arguments by their position
+# Using positional arguments
 # --------------------------------------------------------------------------------
-# Each value is matched to a parameter based on where it appears,
-# so the order of the provided arguments matters.
+# Each value is matched to a parameter based on where it appears, so the order
+# of the provided arguments matters. Positional parameters correspond directly
+# to the order defined in the function signature. Mixing up the order can lead
+# to incorrect results or errors.
 
 def greet(name, age):
     print("Hello, {0}! You are {1} years old.".format(name, age))

--- a/examples/07_functions/func_positional_only_arguments.py
+++ b/examples/07_functions/func_positional_only_arguments.py
@@ -1,6 +1,9 @@
 # Positional-only arguments
 # --------------------------------------------------------------------------------
-# Demonstrates positional-only arguments.
+# Some parameters can be declared positional-only so they cannot be passed by
+# name. This keeps the API minimal and prevents accidental clashes with keyword
+# arguments. The syntax uses a ``/`` in the parameter list to mark the end of
+# positional-only parameters.
 
 # The arguments a and b are positional-only
 def positional_only_arguments(a, b, /):

--- a/examples/07_functions/func_recursion.py
+++ b/examples/07_functions/func_recursion.py
@@ -1,6 +1,9 @@
 # Recursive functions in Python
 # --------------------------------------------------------------------------------
-# Explains how functions can call themselves to solve problems recursively.
+# A recursive function repeatedly calls itself with a simpler version of the
+# original problem. Each call works toward a base case that stops the recursion.
+# This technique is often used for tasks that can be defined in terms of similar
+# subproblems.
 
 def factorial(n):
     # Base case

--- a/examples/07_functions/func_structure.py
+++ b/examples/07_functions/func_structure.py
@@ -1,6 +1,9 @@
 # Anatomy of a Python function
 # --------------------------------------------------------------------------------
-# Describes the structure of a Python function, including parameters, docstrings, and return values.
+# A function definition begins with the ``def`` keyword followed by its name and
+# parameters. The body can perform operations using those parameters and return
+# a value. Well-documented functions include a docstring that briefly states
+# their purpose.
 
 def function_name(parameter1, parameter2):
     """ Docstring: description of the function """

--- a/examples/07_functions/func_variable_arguments_python2.py
+++ b/examples/07_functions/func_variable_arguments_python2.py
@@ -1,10 +1,10 @@
 # Handling a variable number of arguments in Python 2
 # --------------------------------------------------------------------------------
-# Demonstrates capturing extra positional arguments with `*args` and
-# extra keyword arguments with `**kwargs` when keyword-only parameters are
-# unavailable.  In Python 3 you can declare keyword-only parameters using
-# the `*` separator instead of relying on `**kwargs`.  See
-# `func_variable_arguments_python3.py` for comparison.
+# This code captures extra positional arguments with ``*args`` and extra
+# keyword arguments with ``**kwargs`` when keyword-only parameters are
+# unavailable. In Python 3 you can declare keyword-only parameters using the
+# ``*`` separator instead of relying on ``**kwargs``. See
+# ``func_variable_arguments_python3.py`` for comparison.
 
 def variable_number_of_arguments(a, b, *args, **kwargs):
     print("a: {a}".format(a=a))


### PR DESCRIPTION
## Summary
- rewrite headings across `examples/07_functions` to avoid `Demonstrates`/`example`
- expand descriptions to use at least two sentences

## Testing
- `python -m compileall -q examples/07_functions`

------
https://chatgpt.com/codex/tasks/task_e_684a627b20a483249c5145a3e30c1094