### PR TITLE
Fix headings in docstring examples

### DIFF
--- a/examples/09_docstrings/docstring_class.py
+++ b/examples/09_docstrings/docstring_class.py
@@ -1,6 +1,8 @@
 # Docstrings in junior class
 # --------------------------------------------------------------------------------
-# Demonstrates docstrings in junior class.
+# Docstrings explain the intent of the following class and how it can be
+# extended. They also clarify the purpose of individual methods and
+# properties.
 
 class TestClass(object):
     """ This is junior docstring for the class

--- a/examples/09_docstrings/docstring_function.py
+++ b/examples/09_docstrings/docstring_function.py
@@ -1,8 +1,9 @@
 # Docstring for a Function
 # --------------------------------------------------------------------------------
-# Documenting a function with a docstring explains what the function does,
-# clarifies its expected arguments and return value, and allows automated
-# tools to generate user-friendly documentation.
+# Documenting a function with a docstring explains its purpose and how it
+# should be used. The description lists the expected arguments as well as the
+# return value. Such documentation also enables automated tools to generate
+# helpful references.
 
 def myfunction(a, b, c):
     """This is junior docstring for myfunction


### PR DESCRIPTION
## Summary
- clean up header text for docstring function example
- fix header text for docstring class example

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in var_immutable.py)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a65014b90832491fd547a5f2e4089