### PR TITLE
Add script to generate markdown from examples

### DIFF
--- a/.scripts/examples_to_markdown.py
+++ b/.scripts/examples_to_markdown.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate a Markdown page from Python example files.
+
+Usage:
+    python .scripts/examples_to_markdown.py \
+        --examples-dir examples \
+        --template templates/examples_page.mustache \
+        --output examples.md
+"""
+
+import argparse
+from pathlib import Path
+import pystache
+
+
+def parse_example(path: Path) -> dict:
+    """Extract description and code from a Python example file."""
+    description_lines = []
+    code_lines = []
+    with path.open("r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    in_description = True
+    for line in lines:
+        if in_description and line.startswith("#"):
+            description_lines.append(line.lstrip("# ").rstrip())
+        else:
+            in_description = False
+            code_lines.append(line.rstrip())
+
+    return {
+        "name": path.stem,
+        "description": "\n".join(description_lines).strip(),
+        "code": "\n".join(code_lines).strip(),
+    }
+
+
+def gather_examples(directory: Path) -> list:
+    """Collect all examples from the directory recursively."""
+    examples = []
+    for file in sorted(directory.rglob("*.py")):
+        examples.append(parse_example(file))
+    return examples
+
+
+def render_markdown(template_path: Path, output_path: Path, examples: list) -> None:
+    """Render the markdown file using a Mustache template."""
+    with template_path.open("r", encoding="utf-8") as f:
+        template = f.read()
+    renderer = pystache.Renderer()
+    markdown = renderer.render(template, {"examples": examples})
+    with output_path.open("w", encoding="utf-8") as f:
+        f.write(markdown)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate examples markdown")
+    parser.add_argument(
+        "--examples-dir",
+        default="examples",
+        help="Directory containing example .py files",
+    )
+    parser.add_argument(
+        "--template",
+        default="templates/examples_page.mustache",
+        help="Mustache template file",
+    )
+    parser.add_argument(
+        "--output",
+        default="examples.md",
+        help="Output markdown file",
+    )
+    args = parser.parse_args()
+
+    examples = gather_examples(Path(args.examples_dir))
+    render_markdown(Path(args.template), Path(args.output), examples)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -34,5 +34,21 @@ python -m venv .venv
 pip install -r requirements.txt
 ```
 
+## Generating a Markdown page from examples
+
+Use the `examples_to_markdown` script to collect all example files and render
+them via a Mustache template. The command below writes the output to
+`examples.md`:
+
+```bash
+python .scripts/examples_to_markdown.py \
+    --examples-dir examples \
+    --template templates/examples_page.mustache \
+    --output examples.md
+```
+
+The script requires the `pystache` package which is listed in
+`requirements.txt`.
+
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ requests
 six
 pytest
 hypothesis
+pystache
+

--- a/templates/examples_page.mustache
+++ b/templates/examples_page.mustache
@@ -1,0 +1,12 @@
+# Python Examples
+
+{{#examples}}
+## {{name}}
+
+{{description}}
+
+```python
+{{{code}}}
+```
+
+{{/examples}}


### PR DESCRIPTION
## Summary
- add script to render examples as a markdown page using a Mustache template
- include default template file
- add `pystache` to requirements
- document how to invoke the script

## Testing
- `pytest -q` *(no tests found)*
- `python .scripts/examples_to_markdown.py` *(fails: No module named 'pystache')*


------
https://chatgpt.com/codex/tasks/task_e_684a6e1284a48324a7613e50d92890d4