### PR TITLE
Fix pentesting tools heading

### DIFF
--- a/usecases/uc-networks.md
+++ b/usecases/uc-networks.md
@@ -48,8 +48,7 @@ Implement MQTT, CoAP, or WebSocket protocols using `paho-mqtt` and
 Write vulnerability scanners, brute-force tools, and fuzzers leveraging Python  
 security libraries for pentesting and hardening.
 
-Examples pentesting tools include:
-
+Examples of pentesting tools include:
 - Scapy
 - Impacket
 - python-nmap


### PR DESCRIPTION
## Summary
- fix wording of pentesting tools list
- keep bullet list directly under the heading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aa68d336083248f14fd1e10c85a66