### PR TITLE
Fix pillow spelling in docs

### DIFF
--- a/usecases/uc-applications.md
+++ b/usecases/uc-applications.md
@@ -42,7 +42,7 @@ capabilities using Scintilla or Tkinter text widgets.
 
 ### Batch Processing Utilities  
 Design GUIs or CLI tools to process large sets of images, documents or data  
-files in bulk with pillow, OpenCV or pandas.
+files in bulk with Pillow, OpenCV or pandas.
 
 ### Desktop Notifications & Reminders  
 Implement system notifications, pop-ups, and scheduled alerts using plyer  


### PR DESCRIPTION
## Summary
- update pillow reference in application usecase docs

## Testing
- `grep -n "Pillow" -n usecases/uc-applications.md`

------
https://chatgpt.com/codex/tasks/task_e_684aa68c7a7083248414cd5719883214