### PR TITLE
Add nav.yml output option

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -1,11 +1,11 @@
 # Building the Site
 
-This project uses [MkDocs](https://www.mkdocs.org/) to build the static documentation site. After installing the dependencies, regenerate the navigation menu and then run:
+This project uses [MkDocs](https://www.mkdocs.org/) to build the static documentation site. After installing the dependencies, generate the navigation YAML and then run:
 
 ```bash
-python .scripts/update_mkdocs_nav.py
+python .scripts/update_mkdocs_nav.py --nav-file nav.yml
 
-mkdocs build
+mkdocs build -f mkdocs.yml -f nav.yml
 ```
 
 The generated HTML will be placed inside the `site/` directory.


### PR DESCRIPTION
## Summary
- support generating navigation in YAML instead of JSON
- write YAML to `nav.yml` via `--nav-file`
- document nav generation and build process using `nav.yml`

## Testing
- `pytest -q`
- `python .scripts/update_mkdocs_nav.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684ae9c1accc83249713df1a2c8b89c3