### PR TITLE
Add index pages for docs sections

### DIFF
--- a/docs/01_hello_world/index.md
+++ b/docs/01_hello_world/index.md
@@ -1,0 +1,3 @@
+# Hello World
+
+This section provides examples and explanations for **Hello World** in Python.

--- a/docs/02_variables/index.md
+++ b/docs/02_variables/index.md
@@ -1,0 +1,3 @@
+# Variables
+
+This section provides examples and explanations for **Variables** in Python.

--- a/docs/03_comments/index.md
+++ b/docs/03_comments/index.md
@@ -1,0 +1,3 @@
+# Comments
+
+This section provides examples and explanations for **Comments** in Python.

--- a/docs/04_operators/index.md
+++ b/docs/04_operators/index.md
@@ -1,0 +1,3 @@
+# Operators
+
+This section provides examples and explanations for **Operators** in Python.

--- a/docs/05_user_input/index.md
+++ b/docs/05_user_input/index.md
@@ -1,0 +1,3 @@
+# User Input
+
+This section provides examples and explanations for **User Input** in Python.

--- a/docs/06_control_flow/index.md
+++ b/docs/06_control_flow/index.md
@@ -1,0 +1,3 @@
+# Control Flow
+
+This section provides examples and explanations for **Control Flow** in Python.

--- a/docs/07_functions/index.md
+++ b/docs/07_functions/index.md
@@ -1,0 +1,3 @@
+# Functions
+
+This section provides examples and explanations for **Functions** in Python.

--- a/docs/08_classes/index.md
+++ b/docs/08_classes/index.md
@@ -1,0 +1,3 @@
+# Classes
+
+This section provides examples and explanations for **Classes** in Python.

--- a/docs/09_docstrings/index.md
+++ b/docs/09_docstrings/index.md
@@ -1,0 +1,3 @@
+# Docstrings
+
+This section provides examples and explanations for **Docstrings** in Python.

--- a/docs/10_debugging/index.md
+++ b/docs/10_debugging/index.md
@@ -1,0 +1,3 @@
+# Debugging
+
+This section provides examples and explanations for **Debugging** in Python.

--- a/docs/11_oop_pillars/index.md
+++ b/docs/11_oop_pillars/index.md
@@ -1,0 +1,3 @@
+# Oop Pillars
+
+This section provides examples and explanations for **Oop Pillars** in Python.

--- a/docs/12_solid_principles/index.md
+++ b/docs/12_solid_principles/index.md
@@ -1,0 +1,3 @@
+# Solid Principles
+
+This section provides examples and explanations for **Solid Principles** in Python.

--- a/docs/13_logging/index.md
+++ b/docs/13_logging/index.md
@@ -1,0 +1,3 @@
+# Logging
+
+This section provides examples and explanations for **Logging** in Python.

--- a/docs/14_exceptions/index.md
+++ b/docs/14_exceptions/index.md
@@ -1,0 +1,3 @@
+# Exceptions
+
+This section provides examples and explanations for **Exceptions** in Python.

--- a/docs/15_dunder_methods/index.md
+++ b/docs/15_dunder_methods/index.md
@@ -1,0 +1,3 @@
+# Dunder Methods
+
+This section provides examples and explanations for **Dunder Methods** in Python.

--- a/docs/16_data_types/index.md
+++ b/docs/16_data_types/index.md
@@ -1,0 +1,3 @@
+# Data Types
+
+This section provides examples and explanations for **Data Types** in Python.

--- a/docs/17_import_system/index.md
+++ b/docs/17_import_system/index.md
@@ -1,0 +1,3 @@
+# Import System
+
+This section provides examples and explanations for **Import System** in Python.

--- a/docs/18_linting_tools/index.md
+++ b/docs/18_linting_tools/index.md
@@ -1,0 +1,3 @@
+# Linting Tools
+
+This section provides examples and explanations for **Linting Tools** in Python.

--- a/docs/19_test_frameworks/index.md
+++ b/docs/19_test_frameworks/index.md
@@ -1,0 +1,3 @@
+# Test Frameworks
+
+This section provides examples and explanations for **Test Frameworks** in Python.

--- a/docs/20_package_managers/index.md
+++ b/docs/20_package_managers/index.md
@@ -1,0 +1,3 @@
+# Package Managers
+
+This section provides examples and explanations for **Package Managers** in Python.

--- a/docs/21_design_patterns/index.md
+++ b/docs/21_design_patterns/index.md
@@ -1,0 +1,3 @@
+# Design Patterns
+
+This section provides examples and explanations for **Design Patterns** in Python.

--- a/docs/23_meta_classes/index.md
+++ b/docs/23_meta_classes/index.md
@@ -1,0 +1,3 @@
+# Meta Classes
+
+This section provides examples and explanations for **Meta Classes** in Python.

--- a/docs/24_generators/index.md
+++ b/docs/24_generators/index.md
@@ -1,0 +1,3 @@
+# Generators
+
+This section provides examples and explanations for **Generators** in Python.

--- a/docs/25_coroutines/index.md
+++ b/docs/25_coroutines/index.md
@@ -1,0 +1,3 @@
+# Coroutines
+
+This section provides examples and explanations for **Coroutines** in Python.

--- a/docs/28_optimization/index.md
+++ b/docs/28_optimization/index.md
@@ -1,0 +1,3 @@
+# Optimization
+
+This section provides examples and explanations for **Optimization** in Python.

--- a/docs/29_packaging/index.md
+++ b/docs/29_packaging/index.md
@@ -1,0 +1,3 @@
+# Packaging
+
+This section provides examples and explanations for **Packaging** in Python.

--- a/docs/30_compatibility/index.md
+++ b/docs/30_compatibility/index.md
@@ -1,0 +1,3 @@
+# Compatibility
+
+This section provides examples and explanations for **Compatibility** in Python.


### PR DESCRIPTION
## Summary
- add placeholder `index.md` to all documentation folders for better navigation

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6fc1b7a48324a5a1432de53eff28