### PR TITLE
Fix docs script to avoid deleting existing folder

### DIFF
--- a/.scripts/examples_to_markdown_files.py
+++ b/.scripts/examples_to_markdown_files.py
@@ -71,6 +71,11 @@ def main() -> None:
 
     examples_dir = Path(args.examples_dir)
     output_dir = Path(args.output_dir)
+    # Ensure the output directory exists but do not wipe it if it already
+    # contains files. ``exist_ok=True`` prevents accidental deletion of
+    # previously generated documentation.
+    output_dir.mkdir(parents=True, exist_ok=True)
+
     with Path(args.template).open("r", encoding="utf-8") as f:
         template = f.read()
 


### PR DESCRIPTION
## Summary
- ensure `examples_to_markdown_files.py` does not remove the docs directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e702673188324b64480cec6175ed1