### PR TITLE
Fix script names in usage comments

### DIFF
--- a/.scripts/gen_markdown_chapters.py
+++ b/.scripts/gen_markdown_chapters.py
@@ -2,7 +2,7 @@
 """Generate aggregated Markdown files for each examples subfolder.
 
 Usage:
-    python .scripts/examples_to_markdown_files.py \
+    python .scripts/gen_markdown_chapters.py \
         --examples-dir examples \
         --output-dir docs
 

--- a/.scripts/gen_markdown_pages.py
+++ b/.scripts/gen_markdown_pages.py
@@ -2,7 +2,7 @@
 """Generate a Markdown file for each Python example.
 
 Usage:
-    python .scripts/examples_to_markdown_files.py \
+    python .scripts/gen_markdown_pages.py \
         --examples-dir examples \
         --template templates/example_file.mustache \
         --output-dir docs

--- a/.scripts/gen_single_markdown.py
+++ b/.scripts/gen_single_markdown.py
@@ -2,7 +2,7 @@
 """Generate a Markdown page from Python example files.
 
 Usage::
-    python .scripts/examples_to_markdown.py \
+    python .scripts/gen_single_markdown.py \
         --examples-dir examples \
         --template templates/examples_page.mustache \
         --output examples.md


### PR DESCRIPTION
## Summary
- fix outdated script names in comment blocks of markdown generator scripts

## Testing
- `pytest -q`
- `python -m py_compile .scripts/gen_markdown_chapters.py .scripts/gen_markdown_pages.py .scripts/gen_single_markdown.py`


------
https://chatgpt.com/codex/tasks/task_e_6850526e5b988324b42912b4fa97808b