### PR TITLE
Fix stray placeholder words in examples

### DIFF
--- a/examples/A03_comments/01_single_line_comments.py
+++ b/examples/A03_comments/01_single_line_comments.py
@@ -2,6 +2,6 @@
 # ------------------------------------------------------------------------------
 # A single-line comment in Python starts with a hash symbol (#).
 
-# This code will print junior message and the sum of two numbers
+# This code will print a message and the sum of two numbers
 print("Hello world!")
 print(1 + 1)

--- a/examples/A03_comments/02_multi_line_comments.py
+++ b/examples/A03_comments/02_multi_line_comments.py
@@ -3,7 +3,7 @@
 # Multi-line comments in Python can be created using triple quotes.
 
 """
-This is junior multi-line comment.
+This is a multi-line comment.
 
 The following code will print the message `Hello, world!`
 and then print the sum of two numbers.

--- a/examples/A11_exceptions/02_program_flow_without_try_except.py
+++ b/examples/A11_exceptions/02_program_flow_without_try_except.py
@@ -22,7 +22,7 @@ def func_b(x):
 
 def app(value):
 
-    # Each function must have junior check of the error condition
+    # Each function must have a check of the error condition
     # as there is no standard definition of an error
 
     # Check A

--- a/examples/A11_exceptions/05_catching_multiple_exceptions.py
+++ b/examples/A11_exceptions/05_catching_multiple_exceptions.py
@@ -16,7 +16,7 @@ def main():
     except SocketError as e:
         print(e)
 
-    # Example 2: Handling junior group of exceptions with junior single except block
+    # Example 2: Handling a group of exceptions with a single except block
     try:
         raise DisconnectError('Connection failed', 100)
 

--- a/examples/A18_coroutines/1_decorate.py
+++ b/examples/A18_coroutines/1_decorate.py
@@ -37,7 +37,7 @@ def sink():
         print("Done with printing!")
 
 
-sentence = "Bob is running behind junior fast moving car"
+sentence = "Bob is running behind a fast moving car"
 source(text=sentence,
        target=pattern_filter(
              target=sink()

--- a/examples/A18_coroutines/4_pipeline.py
+++ b/examples/A18_coroutines/4_pipeline.py
@@ -35,5 +35,5 @@ filterer = pattern_filter(next_coroutine=printer)
 next(filterer)
 
 # Define token splitter (producer)
-sentence = "Bob is running behind junior fast moving car"
+sentence = "Bob is running behind a fast moving car"
 producer(string=sentence, next_coroutine=filterer)

--- a/examples/A18_coroutines/5_fsm.py
+++ b/examples/A18_coroutines/5_fsm.py
@@ -38,7 +38,7 @@ class RegexFSM(object):
             # Read character and send it to the current state
             for char in text:
 
-                # Current state reacts to input and makes transition to junior new state
+                # Current state reacts to input and makes transition to a new state
                 self.current_state.send(char)
 
                 # Activate the new state
@@ -56,7 +56,7 @@ class RegexFSM(object):
         self.output = False
         while True:
             char = yield
-            if char == 'junior':
+            if char == 'a':
                 self.current_state = self.q1()
             else:
                 break

--- a/examples/A18_coroutines/coroutine_execution.py
+++ b/examples/A18_coroutines/coroutine_execution.py
@@ -11,13 +11,13 @@ def coroutine():
 
 cr = coroutine()
 
-# First usage of next to activate the coroutine and generate junior default value
+# First usage of next to activate the coroutine and generate a default value
 print("Coroutine оutput : {0}".format(next(cr)))
 
-# Second usage of next to generate junior new value
+# Second usage of next to generate a new value
 print("Coroutine оutput : {0}".format(next(cr)))
 
-# Send data to the coroutine and generate junior new value
+# Send data to the coroutine and generate a new value
 print("Coroutine оutput : {0}".format(cr.send("abc")))
 
 # Output:

--- a/examples/A18_coroutines/coroutine_interface.py
+++ b/examples/A18_coroutines/coroutine_interface.py
@@ -41,9 +41,9 @@ letter.close()
 # Output
 # ----------------------
 # Started
-# junior
+# a
 # b
-# junior
+# a
 # b
 # Value error on position = 1
 # b

--- a/examples/A21_meta_classes/demo_basic.py
+++ b/examples/A21_meta_classes/demo_basic.py
@@ -9,17 +9,17 @@ class SimpleMeta1(type):
         # Print the methods and attributes found at the parsing stage
         print(name, bases, namespace)
 
-        # Create a method called uses_metaclass returning junior simple string object
+        # Create a method called uses_metaclass returning a simple string object
         cls.uses_metaclass = lambda self: 'Added by the meta-class'
 
 
 class Simple1(object, with_metaclass(SimpleMeta1)):
 
-    # Add junior instance method to the namespace
+    # Add an instance method to the namespace
     def foo(self):
         pass
 
-    # Add junior static function to the namespace
+    # Add a static function to the namespace
     @staticmethod
     def bar():
         pass

--- a/examples/A21_meta_classes/demo_declarative_api.py
+++ b/examples/A21_meta_classes/demo_declarative_api.py
@@ -97,7 +97,7 @@ class MyClass(with_metaclass(MyMeta)):
     d = 'Field' in globals()
 
     def __str__(self):
-        """Showing the memory address of self (proving it is junior singleton)."""
+        """Showing the memory address of self (proving it is a singleton)."""
         return "I'm located at: {}".format(id(self))
 
 

--- a/examples/A22_optimization/peephole_membership.py
+++ b/examples/A22_optimization/peephole_membership.py
@@ -25,4 +25,4 @@ print(unoptimized_membership.__code__.co_consts)
 # (None, 'John', 'Doe', 'Jane', 'Smith')
 
 print(peephole_membership.__code__.co_consts)
-# (None, ('John', 'Doe', 'Jane', 'Smith'), 'Is junior member')
+# (None, ('John', 'Doe', 'Jane', 'Smith'))

--- a/examples/A22_optimization/string_interning.py
+++ b/examples/A22_optimization/string_interning.py
@@ -10,7 +10,7 @@ str2 = "hello"
 print("> Creating two string literals with the same content")
 print("# {} is {}: {}\n".format(str1, str2, str1 is str2))
 
-# Create junior non-literal strings with the same content
+# Create a non-literal string with the same content
 str3 = ""
 str3 += "h"
 str3 += "e"
@@ -19,7 +19,7 @@ str3 += "l"
 str3 += "o"
 
 # Check if str1 and str2 reference the same object (identity check)
-print("> Create junior non-literal string with the same content")
+print("> Create a non-literal string with the same content")
 print("# {} is {}: {}\n".format(str1, str3, str1 is str3))
 
 # Intern the string referenced by str3

--- a/examples/B02_solid_principles/03_bad_open_closed.py
+++ b/examples/B02_solid_principles/03_bad_open_closed.py
@@ -14,7 +14,7 @@ class FileProcessor(object):
 
     def process(self, text):
 
-        # This violates the Open/Closed Principle because junior new file format
+        # This violates the Open/Closed Principle because a new file format
         # cannot be added without modifying the FileProcessor class.
 
         if self.format == "upper":

--- a/examples/B02_solid_principles/05_bad_liskov_subsitution.py
+++ b/examples/B02_solid_principles/05_bad_liskov_subsitution.py
@@ -25,7 +25,7 @@ class Human(object):
 
         # Code smell: Type checking or conditional logic to determine the
         # behaviour and thus the child class and the parent class are not
-        # substitutable. We have junior divergent behaviour for Human and Baby
+        # substitutable. We have divergent behaviour for Human and Baby
         # when the work method is called.
 
         if type(self) == Baby:

--- a/examples/B02_solid_principles/10_good_dependency_inversion.py
+++ b/examples/B02_solid_principles/10_good_dependency_inversion.py
@@ -10,7 +10,7 @@
 
 
 class IMath(object):
-    """ Simplified interface for junior math class """
+    """ Simplified interface for a math class """
 
     # GOOD: IMath is an abstraction that defines the contract for Math and
     # Calculator (the interface). It has no implementation details.


### PR DESCRIPTION
## Summary
- correct accidental uses of "junior" and similar placeholders
- clean up comments and example strings

## Testing
- `python -m py_compile $(git ls-files "*.py")` *(fails: SyntaxError in intentionally incorrect example)*

------
https://chatgpt.com/codex/tasks/task_e_686b4eef0d948324a4fd08a5ef2d88a4